### PR TITLE
Fourier integral using a linear interpolation on a fixed grid

### DIFF
--- a/neffint/fixed_grid_fourier_integral.py
+++ b/neffint/fixed_grid_fourier_integral.py
@@ -32,7 +32,7 @@ def _lambda(x: ArrayLike) -> np.ndarray:
 
     where j = sqrt(-1) is the imaginary unit.
 
-    For |x| < 1, an Taylor series approximation is summed until convergence is reached.
+    For |x| < 1, a Taylor series approximation is summed until convergence is reached.
 
     :param x: The input variable x, given as a single float or an array of floats.
     :type x: ArrayLike

--- a/tests/test_fixed_grid_fourier_integral.py
+++ b/tests/test_fixed_grid_fourier_integral.py
@@ -42,6 +42,7 @@ def test_lambda():
 
     assert output_lambda == pytest.approx(expected_lambda, rel=comparison_tolerance, abs=comparison_tolerance)
 
+
 def test_phi_and_psi():
     """Test _phi_and_psi against calculation using the analytical formula using 200 decimal digit precision with mpmath."""
     input_x = np.array([1e-9, 1, 1e9, 1e18], dtype=np.float64)
@@ -99,11 +100,12 @@ def test_fourier_integral_fixed_sampling(input_func: Callable[[ArrayLike], Array
 
     assert np.real(output_transform_arr) == pytest.approx(expected_transform_arr, rel=rel_tol)
 
+
 @pytest.mark.parametrize(("interpolation_mode", "tolerances"), [
     (InterpolationMode.PCHIP.value, (1e-4,1e-4)),
     (InterpolationMode.LINEAR.value, (1e-3,5e-3)),
 ])
-def test_full_range_fourier_integral_fixed_sampling_pchip(interpolation_mode: str, tolerances: Tuple[float, float]):
+def test_full_range_fourier_integral_fixed_sampling(interpolation_mode: str, tolerances: Tuple[float, float]):
     """Test Fourier integral accuracy on function with an analytically known Fourier transform on full range."""
     input_func = lambda f: np.sqrt(np.pi/1e10) * np.exp(- np.pi**2 * f**2 / 1e10) # Gaussian
     expected_transform = lambda t: 2*np.pi*np.exp( - 1e10 * t**2)
@@ -122,7 +124,7 @@ def test_full_range_fourier_integral_fixed_sampling_pchip(interpolation_mode: st
         frequencies=input_frequencies,
         func_values=input_func_arr,
         pos_inf_correction_term=True,
-        neg_inf_correction_term=False,
+        neg_inf_correction_term=True,
         interpolation=interpolation_mode
     )
 

--- a/tests/test_fixed_grid_fourier_integral.py
+++ b/tests/test_fixed_grid_fourier_integral.py
@@ -19,12 +19,31 @@ import pytest
 from numpy.typing import ArrayLike
 
 from neffint.fixed_grid_fourier_integral import (
-    InterpolationMode, _fourier_integral_inf_correction, _phi_and_psi,
+    InterpolationMode, _fourier_integral_inf_correction, _lambda, _phi_and_psi,
     fourier_integral_fixed_sampling)
 
 
+def test_lambda():
+    """Test _lambda against calculation with the analytical formula using 200 decimal digit precision with mpmath."""
+    input_x = np.array([1e-9, 1, 1e9, 1e18], dtype=np.float64)
+
+    # Set tolerance to 10*machine precision
+    comparison_tolerance = 10 * np.finfo(input_x.dtype).eps
+
+    # Expected outputs generated with mpmath at 200 decimal digit precision
+    expected_lambda = np.array([
+        0.5+3.333333333333333e-10j,
+        0.3817732906760362+0.3011686789397568j,
+        5.458434492865867e-10-8.378871808180589e-10j,
+        -9.92969320740405e-19-1.1837199021871074e-19j
+    ])
+
+    output_lambda = _lambda(input_x)
+
+    assert output_lambda == pytest.approx(expected_lambda, rel=comparison_tolerance, abs=comparison_tolerance)
+
 def test_phi_and_psi():
-    """Test phi_and_psi against calculation using the analytical formula using 200 decimal digit precision with mpmath."""
+    """Test _phi_and_psi against calculation using the analytical formula using 200 decimal digit precision with mpmath."""
     input_x = np.array([1e-9, 1, 1e9, 1e18], dtype=np.float64)
 
     # Set tolerance to 10*machine precision
@@ -59,7 +78,7 @@ def test_phi_and_psi():
 ])
 def test_fourier_integral_fixed_sampling_pchip(input_func: Callable[[ArrayLike], ArrayLike], expected_transform: Callable[[ArrayLike], ArrayLike], interpolation_mode: str):
     """Test Fourier integral accuracy on function with an analytically known Fourier transform on positive half range."""
-    input_frequencies = np.logspace(-10,20,10000)
+    input_frequencies = np.logspace(-10,20,1000)
     input_times = np.logspace(-15, 0, 50)
 
     input_func_arr = np.array([input_func(freq) for freq in input_frequencies])

--- a/tests/test_fixed_grid_fourier_integral.py
+++ b/tests/test_fixed_grid_fourier_integral.py
@@ -18,8 +18,8 @@ import numpy as np
 import pytest
 from numpy.typing import ArrayLike
 
-from neffint.fixed_grid_fourier_integral import (
-    fourier_integral_fixed_sampling_pchip, _phi_and_psi, fourier_integral_inf_correction)
+from neffint.fixed_grid_fourier_integral import (fourier_integral_fixed_sampling, InterpolationMode,
+    _fourier_integral_fixed_sampling_pchip, _phi_and_psi, fourier_integral_inf_correction)
 
 
 def test_phi_and_psi():
@@ -62,12 +62,13 @@ def test_fourier_integral_fixed_sampling_pchip(input_func: Callable[[ArrayLike],
 
     input_func_arr = np.array([input_func(freq) for freq in input_frequencies])
 
-    output_transform_arr = fourier_integral_fixed_sampling_pchip(
+    output_transform_arr = fourier_integral_fixed_sampling(
         times=input_times,
         frequencies=input_frequencies,
         func_values=input_func_arr,
         pos_inf_correction_term=True,
-        neg_inf_correction_term=False
+        neg_inf_correction_term=False,
+        interpolation=InterpolationMode.PCHIP.value
     )
 
     expected_transform_arr = np.array([expected_transform(time) for time in input_times])
@@ -89,12 +90,13 @@ def test_full_range_fourier_integral_fixed_sampling_pchip():
 
     input_func_arr = np.array([input_func(freq) for freq in input_frequencies])
 
-    output_transform_arr = fourier_integral_fixed_sampling_pchip(
+    output_transform_arr = fourier_integral_fixed_sampling(
         times=input_times,
         frequencies=input_frequencies,
         func_values=input_func_arr,
         pos_inf_correction_term=True,
-        neg_inf_correction_term=True
+        neg_inf_correction_term=True,
+        interpolation=InterpolationMode.PCHIP.value
     )
 
     expected_transform_arr = np.array([expected_transform(time) for time in input_times])


### PR DESCRIPTION
**Depends on #5**

Adds the option to use a linear interpolation instead of a PCHIP interpolation for the fourier integral on a fixed frequency grid.

See section 1.6.3 in [N. Mounet. The LHC Transverse Coupled-Bunch Instability, PhD thesis 5305 (EPFL, 2012)](https://wiki.epfl.ch/nmounet/documents/phd_thesis_nmounet.pdf)