### PR TITLE
Feature/fixed grid pchip fourier integral

### DIFF
--- a/neffint/fixed_grid_fourier_integral.py
+++ b/neffint/fixed_grid_fourier_integral.py
@@ -151,6 +151,8 @@ def fourier_integral_inf_correction(
     :type func_value_end: ArrayLike
     :param func_derivative_end: An array of shape (X1, X2, ...) containing the derivative of the function to be transformed, evaluated at omega_end, defaults to 0
     :type func_derivative_end: ArrayLike, optional
+    :param positive_inf: Flag set to True if the asymptotic correction towards +inf should be calculated, and False if the correction towards -inf should be calculated
+    :type positive_inf: bool, optional
     :return: The asymptotic terms of the Fourier Integral for all times, given as an array of shape (M, X1, X2, ...)
     :rtype: np.ndarray
     

--- a/neffint/fixed_grid_fourier_integral.py
+++ b/neffint/fixed_grid_fourier_integral.py
@@ -1,3 +1,17 @@
+#   Copyright 2023 neffint
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 from typing import Tuple
 
 import numpy as np

--- a/neffint/fixed_grid_fourier_integral.py
+++ b/neffint/fixed_grid_fourier_integral.py
@@ -132,7 +132,13 @@ def _phi_and_psi(x: ArrayLike) -> Tuple[np.ndarray, np.ndarray]:
     
     return phi, psi
 
-def fourier_integral_inf_correction(times: ArrayLike, omega_end: float, func_value_end: ArrayLike, func_derivative_end: ArrayLike=0., positive_inf: bool=True) -> np.ndarray:
+def fourier_integral_inf_correction(
+    times: ArrayLike,
+    omega_end: float,
+    func_value_end: ArrayLike,
+    func_derivative_end: ArrayLike=0.,
+    positive_inf: bool=True
+) -> np.ndarray:
     """Calculate the asymptotic correction term as omega -> +-inf of a Fourier integral for the given times.
     Uses a first or second (if func_derivative_end is given) order Taylor expansion around the angular frequency omega_end.
 

--- a/neffint/fixed_grid_fourier_integral.py
+++ b/neffint/fixed_grid_fourier_integral.py
@@ -1,11 +1,12 @@
-import numpy as np
 from typing import Tuple
+
+import numpy as np
 from numpy.typing import ArrayLike
 from scipy.interpolate import pchip_interpolate
 
 MAX_PHI_PSI_ITERATIONS = 1000
 
-def phi_and_psi(x: ArrayLike) -> Tuple[np.ndarray, np.ndarray]:
+def _phi_and_psi(x: ArrayLike) -> Tuple[np.ndarray, np.ndarray]:
     """Calculates the Phi and Psi functions defined in equations E.142 and E.143 in [1], which are given by:
 
     Phi(x) = -j*exp(j*x)/x - 6j*(exp(j*x)+1)/x^3 + 12(exp(j*x)-1)/x^4,
@@ -145,8 +146,8 @@ def fourier_integral_fixed_sampling_pchip(
     x = delta_omegas*times
 
     exp_x = np.exp(1j * x)
-    phi_x, psi_x = phi_and_psi(x)
-    phi_minus_x, psi_minus_x = phi_and_psi(-x)
+    phi_x, psi_x = _phi_and_psi(x)
+    phi_minus_x, psi_minus_x = _phi_and_psi(-x)
 
     result = np.sum(delta_omegas*exp_omegas*(
         func_values[:, :-1] * phi_minus_x * exp_x + 

--- a/neffint/fixed_grid_fourier_integral.py
+++ b/neffint/fixed_grid_fourier_integral.py
@@ -127,9 +127,9 @@ def fourier_integral_fixed_sampling_pchip(
     """
 
     # Turn inputs into arrays if they are not already, switch to angular frequencies
-    omegas = 2 * np.pi * np.array(frequencies)
-    func_values = np.array(func_values)
-    times = np.array(times)
+    omegas = 2 * np.pi * np.asarray(frequencies)
+    func_values = np.asarray(func_values)
+    times = np.asarray(times)
 
     # Calculate derivatives
     func_derivatives = pchip_interpolate(omegas, func_values, omegas, der=1, axis=0)

--- a/neffint/fixed_grid_fourier_integral.py
+++ b/neffint/fixed_grid_fourier_integral.py
@@ -1,0 +1,118 @@
+import itertools
+
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy.interpolate import pchip_interpolate
+
+MAX_PHI_PSI_ITERATIONS = 1000
+
+
+def phi_and_psi(x: ArrayLike) -> np.ndarray:
+
+    x = np.asarray(x)
+    phi = np.zeros_like(1j*x)
+    psi = np.zeros_like(phi)
+
+    # Set relative tolerance to machine precision
+    rel_tolerance = np.finfo(x.dtype).eps
+
+    big_x_mask = np.abs(x) >= 1
+
+    x_high = x[big_x_mask]
+    exp_jx = np.exp(1j*x_high)
+    phi[big_x_mask] = (-1j*x_high**3 * exp_jx - 6j*x_high*(exp_jx+1) + 12*(exp_jx-1))/x_high**4
+    psi[big_x_mask] = ( x_high**2 * exp_jx + 2j*x_high*(2*exp_jx+1) - 6*(exp_jx-1))/x_high**4
+
+    phi_converged = False
+    psi_converged = False
+    x_low = x[~big_x_mask]
+    inv_factorial = np.ones_like(x_low)
+    power = np.ones_like(x_low, dtype=np.complex256)
+    exp_absx = np.exp(np.abs(x_low))
+
+    for n in itertools.count():
+        if phi_converged and psi_converged:
+            break
+
+        if not phi_converged:
+            phi[~big_x_mask] += (n+6)/((n+3)*(n+4)) * power * inv_factorial
+            phi_converged = np.all(
+                2* np.abs(x_low) * exp_absx * inv_factorial / ((n+1)*(n+5)) <
+                rel_tolerance*np.min([np.abs(np.real(phi[~big_x_mask])), np.abs(np.imag(phi[~big_x_mask]))], axis=0)
+            )
+        
+        if not psi_converged:
+            psi[~big_x_mask] -= 1/((n+3)*(n+4)) * power * inv_factorial
+            psi_converged = np.all(
+                np.abs(x_low) * exp_absx * inv_factorial / ((n+1)*(n+4)*(n+5)) <
+                rel_tolerance*np.min([np.abs(np.real(psi[~big_x_mask])), np.abs(np.imag(psi[~big_x_mask]))], axis=0)
+            )
+        
+        power *= 1j*x_low
+        inv_factorial /= n+1
+
+
+        
+        if n >= MAX_PHI_PSI_ITERATIONS:
+            raise RuntimeError(f"Phi and Psi calculation failed to converge after {n} iterations")
+    
+    return phi, psi
+
+
+def fourier_integral_fixed_sampling_pchip(
+    times: ArrayLike,
+    frequencies: ArrayLike,
+    func_values: ArrayLike,
+    inf_correction_term: bool) -> np.ndarray:
+
+    # Turn inputs into arrays if they are not already, switch to angular frequencies
+    omegas = 2 * np.pi * np.asarray(frequencies)
+    func_values = np.asarray(func_values)
+    times = np.asarray(times)
+
+    # Calculate derivatives
+    func_derivatives = pchip_interpolate(omegas, func_values, omegas, der=1, axis=0)
+
+    # Reshape arrays for correct broadcasting
+    # Now in all arrays:
+    # - Axis 0  : times
+    # - Axis 1  : frequencies
+    # - Axis 2+ : func output dims
+
+    # Add frequency axis
+    times = times[..., np.newaxis]
+
+    # Add time axis
+    omegas = omegas[np.newaxis, ...]
+    func_values = func_values[np.newaxis, ...]
+    func_derivatives = func_derivatives[np.newaxis, ...]
+
+    # Add new axes for each axis of func_values except the frequency and time axes
+    for _ in range(func_values.ndim - 2):
+        omegas = omegas[..., np.newaxis]
+        times = times[..., np.newaxis]
+    
+    # Find deltas
+    delta_omegas = np.diff(omegas, axis=1)
+    exp_omegas = np.exp(1j * omegas[:, :-1] * times)
+
+    x = delta_omegas*times
+
+    exp_x = np.exp(1j * x)
+    phi_x, psi_x = phi_and_psi(x)
+    phi_minus_x, psi_minus_x = phi_and_psi(-x)
+
+    result = np.sum(delta_omegas*exp_omegas*(
+        func_values[:, :-1] * phi_minus_x * exp_x + 
+        func_values[:, 1: ] * phi_x - 
+        delta_omegas*func_derivatives[:, :-1] * psi_minus_x * exp_x + 
+        delta_omegas*func_derivatives[:, 1: ] * psi_x
+    ), axis=1, keepdims=True) # Sum over frequency axis
+
+    if inf_correction_term:
+        result += np.exp(1j*times*omegas[:, -1]) * (1j*func_values[:, -1]/times - func_derivatives[:, -1]/times**2)
+
+    # Remove frequency axis
+    result = np.squeeze(result, axis=1)
+
+    return result

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ VERSION = "0.1.0"
 
 PY_VERSION_REQUIRED = ">=3.7"
 PACKAGES_REQUIRED = {
-    "core": [],
+    "core": [
+        "numpy",
+        "scipy"
+    ],
     "test":[
         "pytest"
     ]

--- a/tests/test_fixed_grid_fourier_integral.py
+++ b/tests/test_fixed_grid_fourier_integral.py
@@ -66,7 +66,8 @@ def test_fourier_integral_fixed_sampling_pchip(input_func: Callable[[ArrayLike],
         times=input_times,
         frequencies=input_frequencies,
         func_values=input_func_arr,
-        inf_correction_term=True,
+        pos_inf_correction_term=True,
+        neg_inf_correction_term=False
     )
 
     expected_transform_arr = np.array([expected_transform(time) for time in input_times])

--- a/tests/test_fixed_grid_fourier_integral.py
+++ b/tests/test_fixed_grid_fourier_integral.py
@@ -5,10 +5,11 @@ import pytest
 from numpy.typing import ArrayLike
 
 from neffint.fixed_grid_fourier_integral import (
-    fourier_integral_fixed_sampling_pchip, phi_and_psi)
+    fourier_integral_fixed_sampling_pchip, _phi_and_psi)
 
 
 def test_phi_and_psi():
+    """Test phi_and_psi against calculation using the analytical formula using 200 decimal digit precision with mpmath."""
     input_x = np.array([1e-9, 1, 1e9, 1e18], dtype=np.float64)
 
     # Set tolerance to 10*machine precision
@@ -29,7 +30,7 @@ def test_phi_and_psi():
         1.1837199021871073658e-37 - 9.9296932074040507374e-37j
     ])
 
-    output_phi, output_psi = phi_and_psi(input_x)
+    output_phi, output_psi = _phi_and_psi(input_x)
 
     assert output_phi == pytest.approx(expected_phi, rel=comparison_tolerance, abs=comparison_tolerance)
     assert output_psi == pytest.approx(expected_psi, rel=comparison_tolerance, abs=comparison_tolerance)
@@ -40,7 +41,8 @@ def test_phi_and_psi():
     ( lambda f: np.array([[1,2],[3,4]]) / np.sqrt( 2 * np.pi * f),  lambda t: np.array([[1,2],[3,4]]) * np.sqrt(np.pi / (2 * t)) ), # Test dimension handling
     ( lambda f: 1 / (1 + (2 * np.pi * f)**2),                       lambda t: np.pi / 2 * np.exp(-t) ),
 ])
-def test_fourier_integral(input_func: Callable[[ArrayLike], ArrayLike], expected_transform: Callable[[ArrayLike], ArrayLike]):
+def test_fourier_integral_fixed_sampling_pchip(input_func: Callable[[ArrayLike], ArrayLike], expected_transform: Callable[[ArrayLike], ArrayLike]):
+    """Test Fourier integral accuracy on function with an analytically known Fourier transform."""
     input_frequencies = np.logspace(-10,20,1000)
     input_times = np.logspace(-15, 0, 50)
 
@@ -55,39 +57,4 @@ def test_fourier_integral(input_func: Callable[[ArrayLike], ArrayLike], expected
 
     expected_transform_arr = np.array([expected_transform(time) for time in input_times])
 
-    assert np.real(output_transform_arr) == pytest.approx(expected_transform_arr, 1e-4)
-
-# @pytest.mark.parametrize(("input_func", "expected_transform"), [
-#     ( lambda f: 1 / np.sqrt( 2 * np.pi * f),                        lambda t: np.sqrt(np.pi / (2 * t)) ),
-#     ( lambda f: np.array([[1,2],[3,4]]) / np.sqrt( 2 * np.pi * f),  lambda t: np.array([[1,2],[3,4]]) * np.sqrt(np.pi / (2 * t)) ), # Test dimension handling
-#     ( lambda f: 1 / (1 + (2 * np.pi * f)**2),                       lambda t: np.pi / 2 * np.exp(-t) ),
-# ])
-# def test_fourier_integral_uneven_sampling(input_func: Callable[[ArrayLike], ArrayLike], expected_transform: Callable[[ArrayLike], ArrayLike]):
-#     # Initialize a random number generator
-#     rng = np.random.default_rng(seed=101)
-
-#     # Logspace-esque distribution from 1e1 to 1e10
-#     random_logspace = 10**(-10+30*rng.random(900))
-
-#     # Gaussian spike at 1e4
-#     random_spike = rng.normal(loc=1e4, scale=5e2, size=100)
-
-#     # Sorted frequencies with an uneven density of frequencies
-#     input_frequencies = np.union1d(random_logspace, random_spike)
-
-#     input_times = np.logspace(-15, 0, 50)
-
-#     input_func_arr = np.array([input_func(freq) for freq in input_frequencies])
-#     input_func_derivative_arr = pchip_interpolate(input_frequencies, input_func_arr, input_frequencies, der=1, axis=0)
-
-#     output_transform_arr = fourier_integral_fixed_sampling(
-#         times=input_times,
-#         omegas=input_frequencies,
-#         func_values=input_func_arr,
-#         func_derivatives=input_func_derivative_arr,
-#         inf_correction_term=True,
-#     )
-
-#     expected_transform_arr = np.array([expected_transform(time) for time in input_times])
-
-#     assert np.real(output_transform_arr) == pytest.approx(expected_transform_arr, 1e-4)
+    assert np.real(output_transform_arr) == pytest.approx(expected_transform_arr, rel=1e-4)

--- a/tests/test_fixed_grid_fourier_integral.py
+++ b/tests/test_fixed_grid_fourier_integral.py
@@ -1,3 +1,17 @@
+#   Copyright 2023 neffint
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 from typing import Callable
 
 import numpy as np

--- a/tests/test_fixed_grid_fourier_integral.py
+++ b/tests/test_fixed_grid_fourier_integral.py
@@ -1,0 +1,93 @@
+from typing import Callable
+
+import numpy as np
+import pytest
+from numpy.typing import ArrayLike
+
+from neffint.fixed_grid_fourier_integral import (
+    fourier_integral_fixed_sampling_pchip, phi_and_psi)
+
+
+def test_phi_and_psi():
+    input_x = np.array([1e-9, 1, 1e9, 1e18], dtype=np.float64)
+
+    # Set tolerance to 10*machine precision
+    comparison_tolerance = 10 * np.finfo(input_x.dtype).eps
+
+    # Expected outputs generated with mpmath at 200 decimal digit precision
+    expected_phi = np.array([
+        0.5 + 3.5e-10j,
+        0.37392456407295215539 + 0.31553567661778005804j,
+        5.4584344944869956752e-10 - 8.3788718136390234542e-10j,
+        -9.9296932074040507621e-19 - 1.1837199021871073261e-19j
+    ])
+
+    expected_psi = np.array([
+        -0.0833333333333333333 - 5e-11j,
+        -0.06739546857228461362 - 0.046145700566923663667j,
+        8.3788717918052853757e-19 + 5.4584345480024828642e-19j,
+        1.1837199021871073658e-37 - 9.9296932074040507374e-37j
+    ])
+
+    output_phi, output_psi = phi_and_psi(input_x)
+
+    assert output_phi == pytest.approx(expected_phi, rel=comparison_tolerance, abs=comparison_tolerance)
+    assert output_psi == pytest.approx(expected_psi, rel=comparison_tolerance, abs=comparison_tolerance)
+
+
+@pytest.mark.parametrize(("input_func", "expected_transform"), [
+    ( lambda f: 1 / np.sqrt( 2 * np.pi * f),                        lambda t: np.sqrt(np.pi / (2 * t)) ),
+    ( lambda f: np.array([[1,2],[3,4]]) / np.sqrt( 2 * np.pi * f),  lambda t: np.array([[1,2],[3,4]]) * np.sqrt(np.pi / (2 * t)) ), # Test dimension handling
+    ( lambda f: 1 / (1 + (2 * np.pi * f)**2),                       lambda t: np.pi / 2 * np.exp(-t) ),
+])
+def test_fourier_integral(input_func: Callable[[ArrayLike], ArrayLike], expected_transform: Callable[[ArrayLike], ArrayLike]):
+    input_frequencies = np.logspace(-10,20,1000)
+    input_times = np.logspace(-15, 0, 50)
+
+    input_func_arr = np.array([input_func(freq) for freq in input_frequencies])
+
+    output_transform_arr = fourier_integral_fixed_sampling_pchip(
+        times=input_times,
+        frequencies=input_frequencies,
+        func_values=input_func_arr,
+        inf_correction_term=True,
+    )
+
+    expected_transform_arr = np.array([expected_transform(time) for time in input_times])
+
+    assert np.real(output_transform_arr) == pytest.approx(expected_transform_arr, 1e-4)
+
+# @pytest.mark.parametrize(("input_func", "expected_transform"), [
+#     ( lambda f: 1 / np.sqrt( 2 * np.pi * f),                        lambda t: np.sqrt(np.pi / (2 * t)) ),
+#     ( lambda f: np.array([[1,2],[3,4]]) / np.sqrt( 2 * np.pi * f),  lambda t: np.array([[1,2],[3,4]]) * np.sqrt(np.pi / (2 * t)) ), # Test dimension handling
+#     ( lambda f: 1 / (1 + (2 * np.pi * f)**2),                       lambda t: np.pi / 2 * np.exp(-t) ),
+# ])
+# def test_fourier_integral_uneven_sampling(input_func: Callable[[ArrayLike], ArrayLike], expected_transform: Callable[[ArrayLike], ArrayLike]):
+#     # Initialize a random number generator
+#     rng = np.random.default_rng(seed=101)
+
+#     # Logspace-esque distribution from 1e1 to 1e10
+#     random_logspace = 10**(-10+30*rng.random(900))
+
+#     # Gaussian spike at 1e4
+#     random_spike = rng.normal(loc=1e4, scale=5e2, size=100)
+
+#     # Sorted frequencies with an uneven density of frequencies
+#     input_frequencies = np.union1d(random_logspace, random_spike)
+
+#     input_times = np.logspace(-15, 0, 50)
+
+#     input_func_arr = np.array([input_func(freq) for freq in input_frequencies])
+#     input_func_derivative_arr = pchip_interpolate(input_frequencies, input_func_arr, input_frequencies, der=1, axis=0)
+
+#     output_transform_arr = fourier_integral_fixed_sampling(
+#         times=input_times,
+#         omegas=input_frequencies,
+#         func_values=input_func_arr,
+#         func_derivatives=input_func_derivative_arr,
+#         inf_correction_term=True,
+#     )
+
+#     expected_transform_arr = np.array([expected_transform(time) for time in input_times])
+
+#     assert np.real(output_transform_arr) == pytest.approx(expected_transform_arr, 1e-4)

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,0 @@
-def test_placeholder():
-    """Placeholder test to initialize repository. To be deleted upon adding actual code and tests."""
-    assert 1 + 1 == 2


### PR DESCRIPTION
Depends on #1

Copy of #2 to get comparison against current state of main.

Implements a function `fourier_integral_fixed_sampling_pchip` which takes an array of frequencies $f$ and an array of corresponding function outputs for some function $g(f)$ and calculates the fourier integral of $g$ at times $t$ also given as an input.

The calculation approximates the function as a piecewise cubic Hermite interpolating polynomial (PCHIP) and calculates the fourier integral analytically for this interpolating polynomial.

Heavily based on section 1.6.3 in [N. Mounet. The LHC Transverse Coupled-Bunch Instability, PhD thesis 5305 (EPFL, 2012)](https://wiki.epfl.ch/nmounet/documents/phd_thesis_nmounet.pdf)